### PR TITLE
remove deps; detect failed jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/jobs.cpython-39.pyc
 fnord
 k8s/counts.txt
 .vs/
+.vscode/

--- a/test_k8s.py
+++ b/test_k8s.py
@@ -3,9 +3,21 @@
 import k8s
 
 
+def test_cluster_config():
+    assert(k8s.check_cluster_config())
+
+
 def test_run_and_wait():
     result = k8s.wait(k8s.run(lambda: "Hooray"), timeout=30)
     assert(result=="Hooray")
+
+
+def test_fail():
+    try:
+        k8s.wait(k8s.run(lambda: 1/0), timeout=30)
+    except RuntimeError:
+        return
+    assert(False)
 
 
 def test_map():
@@ -14,21 +26,18 @@ def test_map():
 
 
 def test_deps():
-    job1 = k8s.run(lambda: "job-1", deps=[])
-    job2 = k8s.run(lambda j=job1, **kwargs: "job-2 " + kwargs["inputs"][j], deps=[job1])
+    job1 = k8s.run(lambda: "job-1")
+    job2 = k8s.run(lambda result=k8s.wait(job1): "job-2 " + result) 
     result = k8s.wait(job2, timeout=30)
-    # clean up job1
-    k8s.wait(job1, timeout=30)
     assert(result == "job-2 job-1")
 
 
 def test_simple_workflow():
-    jobs1 = k8s.map(lambda i: i, range(3), nowait=True)
-    jobs2 = k8s.map(lambda i, **kwargs: sum(kwargs["inputs"].values()), range(3), deps=jobs1, nowait=True)
-    results = [k8s.wait(j, timeout=30) for j in jobs2]
-    # clean up jobs1
-    _ = [k8s.wait(j, timeout=30) for j in jobs1]
-    assert(tuple(results) == (3, 3, 3))
+    def wf():
+        jobs1 = k8s.map(lambda i: i, range(3), nowait=True)
+        return k8s.wait(k8s.run(lambda inputs: sum(inputs), map(k8s.wait, jobs1)), timeout=30)
+    result = k8s.wait(k8s.run(wf), timeout=60)
+    assert(result == 3)
 
 
 def test_nested_lambda():
@@ -37,7 +46,7 @@ def test_nested_lambda():
     assert(result == 30)
 
 
-#def test_ngs_workflow():
-#    from example_workflow import ngs_workflow
-#    results = ngs_workflow("batch-1")
-#    assert(results.__class__ == dict)
+def test_ngs_workflow():
+    from example_workflow import ngs_workflow
+    results = ngs_workflow("batch-1")
+    assert(results.__class__ == dict)


### PR DESCRIPTION
No more explicit handling of dependencies; do it within jobs instead.

Also now k8s.wait() raises a RuntimeError if a job fails.